### PR TITLE
Added in missing CIGAR symbols

### DIFF
--- a/Bio-SamTools/lib/Bio/DB/Bam/AlignWrapper.pm
+++ b/Bio-SamTools/lib/Bio/DB/Bam/AlignWrapper.pm
@@ -148,7 +148,7 @@ sub split_splices {
 	} else {
 	    $partial_cigar .= "$operation$count";
 	}
-	$end  += $count if $operation =~ /^[MDSHP]/i;
+	$end  += $count if $operation =~ /^[MDSHP=X]/i;
 	$skip += $count if $operation eq 'N';
 	if ($operation eq 'H' and $start == 0) {
 	    $qseq = 'N' x $count . $qseq;
@@ -267,7 +267,7 @@ sub dna {
 	my $seq   = '';
 	for my $op (@$cigar) {
 	    my ($operation,$count) = @$op;
-	    if ($operation eq 'M') {
+	    if ($operation eq 'M' || $operation eq '=' || $operation eq 'X') {
 		$seq .= substr($qseq,0,$count,''); # include these residues
 	    } elsif ($operation eq 'S' or $operation eq 'I') {
 		substr($qseq,0,$count,'');         # skip soft clipped and inserted residues

--- a/Bio-SamTools/lib/Bio/DB/Bam/Alignment.pm
+++ b/Bio-SamTools/lib/Bio/DB/Bam/Alignment.pm
@@ -586,11 +586,11 @@ sub mate_len {
     my $len     = $self->length;
 
     my $adjust = 0;
-    my @cigar   = $self->cigar_str =~ /(\d+)(\w)/g;
-    while (@cigar) {
-	my ($len,$op) = splice(@cigar,0,2);
-	$adjust += $len if $op eq 'I';
-	$adjust -= $len if $op eq 'D';
+    my @cigar = $self->cigar_array;
+    for my $event (@cigar) {
+        my ($op,$len) = @event;
+        $adjust += $len if $op eq 'I';
+        $adjust -= $len if $op eq 'D';
     }
 
     return $adjust + $ins_len + ($self->start-$self->mate_start) if $ins_len > 0;

--- a/Bio-SamTools/lib/Bio/DB/Sam/Constants.pm
+++ b/Bio-SamTools/lib/Bio/DB/Sam/Constants.pm
@@ -73,7 +73,7 @@ our @EXPORT = qw(CIGAR_SYMBOLS BAM_CIGAR_SHIFT BAM_CIGAR_MASK
                  BAM_CSOFT_CLIP BAM_CHARD_CLIP BAM_CPAD FLAGS RFLAGS);
 our @EXPORT_OK = @EXPORT;
 
-use constant CIGAR_SYMBOLS   => [qw(M I D N S H P)];
+use constant CIGAR_SYMBOLS   => [qw(M I D N S H P = X)];
 use constant BAM_CIGAR_SHIFT => 4;
 use constant BAM_CIGAR_MASK  => (1 << BAM_CIGAR_SHIFT) - 1;
 use constant BAM_CMATCH      => 0;


### PR DESCRIPTION
'=' for sequence match & 'X' for sequence mismatch.