### PR TITLE
Fix for changes in jksrc 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+notifications:
+  slack: wtsi-cgpit:vtT8FxSRsOnHblGjzu6YTfvN
+  email: false
+
+env:
+ - CC=gcc
+
+addons:
+ apt:
+  packages:
+   - build-essential
+   - curl
+   - libcurl4-openssl-dev
+   - zlib1g-dev
+   - libncurses5-dev
+   - libpstreams-dev
+   - unzip
+   - libpng12-dev
+   - libexpat1-dev
+
+language: perl
+
+perl:
+ - "5.22"
+
+install: true
+
+script:
+ - Bio-BigFile/travis/setup.sh ~/build ftp://ftp.sanger.ac.uk/pub/cancer/legacy-dependancies/jksrc.v336.zip
+
+# force more

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ perl:
 install: true
 
 script:
- - Bio-BigFile/travis/setup.sh ~/build ftp://ftp.sanger.ac.uk/pub/cancer/legacy-dependancies/jksrc.v336.zip
+ - Bio-BigFile/travis/setup.sh ~/build
+ # add an extra param to download jksrc.zip from a different location, default can be slow/intermittent
 
-# force more

--- a/Bio-BigFile/Build.PL
+++ b/Bio-BigFile/Build.PL
@@ -5,9 +5,11 @@ use Module::Build;
 
 my $HeaderFile = "bigWig.h";
 my $LibFile    = "jkweb.a";
+my $HeaderFileHTS = "tbx.h";
+my $LibFileHTS    = "libhts.a";
 my $ReadLine;
 
-my ($jk_include,$jk_lib) = find_jk(); # may exit with error here
+my ($jk_include,$jk_lib,$hts_include,$hts_lib) = find_jk(); # may exit with error here
 
 my $build = Module::Build->new(
     module_name        => 'Bio::BigFile',
@@ -15,8 +17,8 @@ my $build = Module::Build->new(
     dist_author        => 'Lincoln Stein <lincoln.stein@gmail.com>',
     dist_abstract      => "Manipulate Jim Kent's BigWig and BigBed index files for genomic features.",
     license            => 'perl',
-    include_dirs       => [$jk_include],
-    extra_linker_flags => ["$jk_lib/$LibFile",'-lz','-lssl'],
+    include_dirs       => [$jk_include,$hts_include],
+    extra_linker_flags => ["$jk_lib/$LibFile","$hts_lib/$LibFileHTS",'-lz','-lssl','-pthread'],
 
     extra_compiler_flags=>[
 	# turn off warnings originating in Perl's Newx* calls
@@ -45,14 +47,15 @@ $build->create_build_script;
 exit 0;
 
 sub find_jk {
-    my ($jk_include,$jk_lib);
+    my ($jk_include,$jk_lib,$hts_include,$hts_lib);
 
     if (my $jksrc = $ENV{KENT_SRC}) {
-	$jk_include = "$jksrc/inc"
-	    if -e "$jksrc/inc/$HeaderFile";
-	$jk_lib     = "$jksrc/lib/$ENV{MACHTYPE}"
-	    if -e "$jksrc/lib/$ENV{MACHTYPE}/$LibFile";
+      $jk_include  = "$jksrc/inc" if -e "$jksrc/inc/$HeaderFile";
+      $jk_lib      = "$jksrc/lib/$ENV{MACHTYPE}" if -e "$jksrc/lib/$ENV{MACHTYPE}/$LibFile";
+      $hts_include = "$jksrc/htslib" if -e "$jksrc/htslib/htslib/$HeaderFileHTS";
+      $hts_lib     = "$jksrc/htslib" if -e "$jksrc/htslib/$LibFileHTS";
     }
+
 
     unless ($jk_include && $jk_lib) {
 	print STDERR <<END;
@@ -62,7 +65,7 @@ If you haven't already done so, please download the source from
 http://hgdownload.cse.ucsc.edu/admin/jksrc.zip, unpack it, and build the
 contents of the "kent/src/lib" subdirectory as directed in the README. Then
 enter the location of the "kent/src" subdirectory at the prompt below. To prevent
-this message from appearing in the future, set the environment variable KENT_SRC 
+this message from appearing in the future, set the environment variable KENT_SRC
 to point to the "kent/src" subdirectory.
 
 END
@@ -72,18 +75,21 @@ END
 	    my $path = prompt($prompt);
 	    print STDERR "\n";
 	    last unless $path;
-	    $jk_include = "$path/inc"
-		if -e "$path/inc/$HeaderFile";
-	    $jk_lib = "$path/lib/$ENV{MACHTYPE}"
-		if -e "$path/lib/$ENV{MACHTYPE}/$LibFile";
-	    $found = $jk_include && $jk_lib;
+
+      $jk_include  = "$path/inc" if -e "$path/inc/$HeaderFile";
+      $jk_lib      = "$path/lib/$ENV{MACHTYPE}" if -e "$path/lib/$ENV{MACHTYPE}/$LibFile";
+      $hts_include = "$path/htslib" if -e "$path/htslib/htslib/$HeaderFileHTS";
+      $hts_lib     = "$path/htslib" if -e "$path/htslib/$LibFileHTS";
+
+
+	    $found = $jk_include && $jk_lib && $hts_include && $hts_lib;
 	    unless ($found) {
 		print STDERR "Can't find the $HeaderFile and $LibFile files at this location.\n";
 		$prompt = "Try again, or hit <enter> to cancel: ";
 	    }
 	}
     }
-    return ($jk_include,$jk_lib);
+    return ($jk_include,$jk_lib,$hts_include,$hts_lib);
 }
 
 
@@ -97,7 +103,7 @@ sub prompt {
 	eval {readline::rl_set('TcshCompleteMode','On')};
     }
 
-    
+
     unless ($ReadLine) {
 	print STDOUT $msg;
 	chomp (my $in = <>);

--- a/Bio-BigFile/Changes
+++ b/Bio-BigFile/Changes
@@ -1,3 +1,7 @@
+Version NEXT
+        * Update Build.PL to link new required elements of jksrc
+        * Added travis build
+
 Version 1.07
         * Allow -types to be used as an alias for -type in calls to features()
 	  and get_seq_stream().
@@ -9,9 +13,9 @@ Version 1.05
 	* Added patch to Jim Kent build tree to allow for compilation on
 	MacOS X.
 
-Version 1.04 
-	 * Added the following methods to Bio::DB::BigWig::Summary objects: 
-	 chr_stats(),    chr_mean(),    chr_stdev(), 
+Version 1.04
+	 * Added the following methods to Bio::DB::BigWig::Summary objects:
+	 chr_stats(),    chr_mean(),    chr_stdev(),
 	 global_stats(), global_mean(), global_stdev().
 	 * Fixed BigWigSet->get_feature_by_id() to return correct class of
 	   object (e.g. summary).
@@ -24,7 +28,7 @@ Version 1.02
 	* BigWigSet now operates correctly on remote HTTP and FTP directories.
 	* Added instructions and patch file for compiling on MacOSX platforms.
 
-Version 1.01 
+Version 1.01
         * fixed bug in build process -- not finding jkweb.a library or
 	header files when path entered at the prompt.
 

--- a/Bio-BigFile/README
+++ b/Bio-BigFile/README
@@ -13,6 +13,10 @@ get, unpack and compile the necessary file are:
 
  wget http://hgdownload.cse.ucsc.edu/admin/jksrc.zip
  unzip jksrc.zip
+ perl -pi -e 's/(\s+CFLAGS=)$/${1}-fPIC/' kent/src/inc/common.mk
+ perl -pi -e 'if($_ =~ m/^CFLAGS/ && $_ !~ m/\-fPIC/i){chomp; s/#.+//; $_ .= " -fPIC -Wno-unused -Wno-unused-result\n"};' kent/src/htslib/Makefile
+ cd kent/htslib
+ make
  cd kent/src/lib
  export    MACHTYPE=i686    # for a 64-bit system
  # export  MACHTYPE=i386    # for a 32-bit system
@@ -53,7 +57,7 @@ following line:
 
  Old:
   CFLAGS=
-     
+
  New:
   CFLAGS=-fPIC
 
@@ -85,7 +89,7 @@ to set the environment variable MACHTYPE to point to the appropriate
 architecture for your system. This is described in the installation
 directions for the Jim Kent source tree.
 
-AUTHOR: 
+AUTHOR:
 
 Lincoln D. Stein <lincoln.stein@gmail.com>
 

--- a/Bio-BigFile/travis/setup.sh
+++ b/Bio-BigFile/travis/setup.sh
@@ -3,8 +3,7 @@
 set -uex
 
 # for Bio::DB::BigWig
-#SOURCE_KENTSRC="ftp://ftp.sanger.ac.uk/pub/cancer/legacy-dependancies/jksrc.v334.zip"
-SOURCE_KENTSRC="ftp://ftp.sanger.ac.uk/pub/cancer/legacy-dependancies/jksrc.v336.zip"
+SOURCE_KENTSRC="http://hgdownload.cse.ucsc.edu/admin/jksrc.zip"
 SOURCE_BIGFILE="http://www.cpan.org/authors/id/L/LD/LDS/Bio-BigFile-1.07.tar.gz"
 
 CPU=`grep -c ^processor /proc/cpuinfo`

--- a/Bio-BigFile/travis/setup.sh
+++ b/Bio-BigFile/travis/setup.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -uex
+
+# for Bio::DB::BigWig
+#SOURCE_KENTSRC="ftp://ftp.sanger.ac.uk/pub/cancer/legacy-dependancies/jksrc.v334.zip"
+SOURCE_KENTSRC="ftp://ftp.sanger.ac.uk/pub/cancer/legacy-dependancies/jksrc.v336.zip"
+SOURCE_BIGFILE="http://www.cpan.org/authors/id/L/LD/LDS/Bio-BigFile-1.07.tar.gz"
+
+CPU=`grep -c ^processor /proc/cpuinfo`
+
+get_distro () {
+  EXT=""
+  if [[ $2 == *.tar.bz2* ]] ; then
+    EXT="tar.bz2"
+  elif [[ $2 == *.zip* ]] ; then
+    EXT="zip"
+  elif [[ $2 == *.tar.gz* ]] ; then
+    EXT="tar.gz"
+  else
+    echo "I don't understand the file type for $1"
+    exit 1
+  fi
+  if hash curl 2>/dev/null; then
+    curl -sS -o $1.$EXT -L $2
+  else
+    wget -nv -O $1.$EXT $2
+  fi
+}
+
+get_file () {
+# output, source
+  if hash curl 2>/dev/null; then
+    curl -sS -o $1 -L $2
+  else
+    wget -nv -O $1 $2
+  fi
+}
+
+INST_PATH=$1
+if [ "$#" -eq "2" ] ; then
+  SOURCE_KENTSRC=$2
+fi
+
+# get current directory
+INIT_DIR=`pwd`
+
+# cleanup inst_path
+mkdir -p $INST_PATH
+cd $INST_PATH
+INST_PATH=`pwd`
+mkdir -p $INST_PATH/bin
+cd $INIT_DIR
+
+unset PERL5LIB
+PERLROOT=$INST_PATH/lib/perl5
+export PERL5LIB="$PERLROOT"
+export PATH="$INST_PATH/bin:$PATH"
+
+#create a location to build dependencies
+SETUP_DIR=$INIT_DIR/install_tmp
+mkdir -p $SETUP_DIR
+
+get_file $SETUP_DIR/cpanm https://cpanmin.us/
+perl $SETUP_DIR/cpanm -l $INST_PATH App::cpanminus
+CPANM=`which cpanm`
+
+if [ -e $SETUP_DIR/basePerlDeps.success ]; then
+  echo "Previously installed base perl deps..."
+else
+  perlmods=( "ExtUtils::CBuilder" "Module::Build~0.42" "LWP::UserAgent" "Bio::Root::Version~1.006009001")
+  for i in "${perlmods[@]}" ; do
+    $CPANM -v --no-interactive --notest --mirror http://cpan.metacpan.org -l $INST_PATH $i
+  done
+  touch $SETUP_DIR/basePerlDeps.success
+fi
+
+cd $SETUP_DIR
+if [ -e $SETUP_DIR/kentsrc.success ]; then
+  echo "Previously unpacked kentsrc..."
+else
+  rm -rf kent kentsrc.zip
+  get_distro "kentsrc" $SOURCE_KENTSRC
+  unzip -q kentsrc.zip
+  perl -pi -e 's/(\s+CFLAGS=)$/${1}-fPIC/' kent/src/inc/common.mk
+  perl -pi -e 'if($_ =~ m/^CFLAGS/ && $_ !~ m/\-fPIC/i){chomp; s/#.+//; $_ .= " -fPIC -Wno-unused -Wno-unused-result\n"};' kent/src/htslib/Makefile
+  touch $SETUP_DIR/kentsrc.success
+fi
+
+cd kent/src/htslib
+make -j$CPU
+cd ../lib
+export MACHTYPE=i686    # for a 64-bit system
+make -j$CPU
+cd ../
+export KENT_SRC=`pwd`
+cd $SETUP_DIR
+cd $INIT_DIR/Bio-BigFile
+perl Build.PL --install_base=$INST_PATH
+./Build clean
+./Build
+./Build test
+./Build install
+rm -f kentsrc.zip
+
+

--- a/Bio-BigFile/travis/setup.sh
+++ b/Bio-BigFile/travis/setup.sh
@@ -58,6 +58,19 @@ export PATH="$INST_PATH/bin:$PATH"
 SETUP_DIR=$INIT_DIR/install_tmp
 mkdir -p $SETUP_DIR
 
+cd $SETUP_DIR
+if [ -e $SETUP_DIR/kentsrc.success ]; then
+  echo "Previously unpacked kentsrc..."
+else
+  rm -rf kent kentsrc.zip
+  get_distro "kentsrc" $SOURCE_KENTSRC
+  unzip -q kentsrc.zip
+  perl -pi -e 's/(\s+CFLAGS=)$/${1}-fPIC/' kent/src/inc/common.mk
+  perl -pi -e 'if($_ =~ m/^CFLAGS/ && $_ !~ m/\-fPIC/i){chomp; s/#.+//; $_ .= " -fPIC -Wno-unused -Wno-unused-result\n"};' kent/src/htslib/Makefile
+  touch $SETUP_DIR/kentsrc.success
+fi
+
+
 get_file $SETUP_DIR/cpanm https://cpanmin.us/
 perl $SETUP_DIR/cpanm -l $INST_PATH App::cpanminus
 CPANM=`which cpanm`
@@ -70,18 +83,6 @@ else
     $CPANM -v --no-interactive --notest --mirror http://cpan.metacpan.org -l $INST_PATH $i
   done
   touch $SETUP_DIR/basePerlDeps.success
-fi
-
-cd $SETUP_DIR
-if [ -e $SETUP_DIR/kentsrc.success ]; then
-  echo "Previously unpacked kentsrc..."
-else
-  rm -rf kent kentsrc.zip
-  get_distro "kentsrc" $SOURCE_KENTSRC
-  unzip -q kentsrc.zip
-  perl -pi -e 's/(\s+CFLAGS=)$/${1}-fPIC/' kent/src/inc/common.mk
-  perl -pi -e 'if($_ =~ m/^CFLAGS/ && $_ !~ m/\-fPIC/i){chomp; s/#.+//; $_ .= " -fPIC -Wno-unused -Wno-unused-result\n"};' kent/src/htslib/Makefile
-  touch $SETUP_DIR/kentsrc.success
 fi
 
 cd kent/src/htslib

--- a/Bio-BigFile/travis/setup.sh
+++ b/Bio-BigFile/travis/setup.sh
@@ -2,9 +2,7 @@
 
 set -uex
 
-# for Bio::DB::BigWig
 SOURCE_KENTSRC="http://hgdownload.cse.ucsc.edu/admin/jksrc.zip"
-SOURCE_BIGFILE="http://www.cpan.org/authors/id/L/LD/LDS/Bio-BigFile-1.07.tar.gz"
 
 CPU=`grep -c ^processor /proc/cpuinfo`
 


### PR DESCRIPTION
Fixes #17 
- Fixes linking in `Build.PL` to handle new htslib requirement
- Adds basic travis-ci (for Bio-BigFile) to verify release works with most recent `jksrc.zip`
  - The downloads from UCSC can occasionally fail, should fail fast though
- Updates build method in `README`

@cjfields: Also reviewed the changes in branch `topic/kent_jan2014`, looks like the need for these has been removed as the modified API element has been reintroduced, the altered use is available via a different name now.
