### PR TITLE
Should mitigate the fp comparison problems

### DIFF
--- a/Bio-BigFile/t/01.bigwig.t
+++ b/Bio-BigFile/t/01.bigwig.t
@@ -29,7 +29,7 @@ use Bio::DB::BigFile;
 use Bio::DB::BigFile::Constants;
 use File::Temp 'tempfile';
 
-# low level tests (defined in lib/Bio/DB/Sam.xs) 
+# low level tests (defined in lib/Bio/DB/Sam.xs)
 ok('loaded ok');
 
 # constants
@@ -40,7 +40,7 @@ my $wig      = Bio::DB::BigFile->bigWigFileOpen($testfile);
 ok($wig);
 ok($wig->isa('Bio::DB::bbiFile'));
 
-# does dumping work? 
+# does dumping work?
 my $fh = tempfile();
 ok($wig->bigWigIntervalDump('I',1,5000,0,$fh));
 seek ($fh,0,0);
@@ -86,19 +86,19 @@ my $extended_summary = $wig->bigWigSummary('I',1,5000000,500);
 ok ($extended_summary);
 ok ($extended_summary->isa('Bio::DB::bbiExtendedSummary'));
 ok ($extended_summary->validCount(0) > 0);
-ok ($extended_summary->sumData(1)/$extended_summary->validCount(1),$summary->[1]);
+ok (sprintf("%.6f", $extended_summary->sumData(1)/$extended_summary->validCount(1)), sprintf("%.6f", $summary->[1]));
 
 my $bin_sum = $wig->bigWigBinStats('I',1,5000000,500);
 ok ($bin_sum);
 ok (scalar @$bin_sum,500);
-ok($bin_sum->[300]->sumData/$bin_sum->[300]->validCount,$summary->[300]);
+ok(sprintf("%.6f", $bin_sum->[300]->sumData/$bin_sum->[300]->validCount), sprintf("%.6f", $summary->[300]));
 
 my $es_list = $wig->bigWigSummaryArrayExtended('I',1,5000000,500);
 ok($es_list);
 ok(ref $es_list,'ARRAY');
 ok(scalar @$es_list,500);
 ok(join(' ',sort keys %{$es_list->[0]}),"maxVal minVal sumData sumSquares validCount");
-ok($es_list->[300]{sumData}/$es_list->[300]{validCount},$summary->[300]);
+ok(sprintf("%.6f", $es_list->[300]{sumData}/$es_list->[300]{validCount}), sprintf("%.6f", $summary->[300]));
 
 my $value = $wig->bigWigSingleSummary('I',1,5000000,bbiSumMean,'NaN');
 ok ($value > 0);

--- a/Bio-BigFile/t/02.bigbed.t
+++ b/Bio-BigFile/t/02.bigbed.t
@@ -50,7 +50,7 @@ ok(defined $summary->[-1]);
 my $es = $bed->bigBedSummaryArrayExtended('chr1',0,12_000_000,500);
 ok ($es);
 ok(scalar @$es,500);
-ok($es->[-2]{validCount}/(12_000_000/500),$summary->[-2]);
+ok(sprintf("%.6f", $es->[-2]{validCount}/(12_000_000/500)), sprintf("%.6f", $summary->[-2]));
 
 my $as = $bed->bigBedAs;
 ok($as);


### PR DESCRIPTION
This will resolve #16.  Not perfect, precision may want to be higher (perhaps `%.12f`?).  From the bug report seemed to be stable down to 15 dp.